### PR TITLE
equals() 가 올바르게 id 비교를 할 수 있게 수정

### DIFF
--- a/src/main/java/com/example/projectboard/domain/Article.java
+++ b/src/main/java/com/example/projectboard/domain/Article.java
@@ -51,11 +51,11 @@ public class Article extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false;
+        if (!(o instanceof Article that)) return false;
         // 지금 막 만든 아직 영속화되지 않은 엔티티는 모두 동등성 검사 탈락(각각 다른 값으로 보겠다.)
         // id가 부여되지 않았다면 동등성 검사 자체가 의미 없다는 것으로 보고 다 다른 것으로 간주하거나 혹은 처리하지 않겠다.
         // id가 같다면 당연히 두 객체는 같은 객체이다.
-        return id != null && id.equals(article.id);
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/example/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/example/projectboard/domain/ArticleComment.java
@@ -44,7 +44,7 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/example/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/example/projectboard/domain/UserAccount.java
@@ -44,8 +44,8 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        if (!(o instanceof UserAccount that)) return false;
+        return userId != null && userId.equals(that.getUserId());
     }
 
     @Override


### PR DESCRIPTION
테스트해 보니 `that.id`와 같은 표현은
의도하지 않은 동작을 만들었다.
제대로 getter 를 써서 값을 불러오게 수정
이름도 `that`으로 통일